### PR TITLE
feat - Se agregó una funcion de formateo de numero

### DIFF
--- a/src/pages/Dashboard/ui/CardData/CardData.jsx
+++ b/src/pages/Dashboard/ui/CardData/CardData.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router'
 import './CardData.css'
 import { Loader } from '../../../../components/Loader/Loader'
+import { formatearNumero } from '../../../../utils/formatearNumero'
 export function CardData({title,Icon,number,description, link,name, loading}){
   return(
     <article className='card-data__container box-border'>
@@ -12,7 +13,7 @@ export function CardData({title,Icon,number,description, link,name, loading}){
         {/* Numero de la card */}
         {
           // En caso de estar cargando muestra el loader
-          loading ? <Loader /> : <p className='card-data__number'>{number}</p>
+          loading ? <Loader /> : <p className='card-data__number'>{formatearNumero(number)}</p>
         }
 
         {/* Descripcion de la card */}

--- a/src/utils/formatearNumero.js
+++ b/src/utils/formatearNumero.js
@@ -1,0 +1,4 @@
+export function formatearNumero(numero){
+  // Funcion que coloca los puntos de las unidades y comas utilizando el formato alemán.
+  return numero.toLocaleString('de-DE')
+}


### PR DESCRIPTION
Se agrego nueva funcionalidad que formatea los numero en el formato aleman( '.' para unidades de mil y ',' para parte decimal) para mostrar de manera mas clara los numeros en nuestra pagina.

Captura sin la nueva funcionalidad.
<img width="1142" height="403" alt="{6FC7197C-0DE7-41C3-93FC-952EA232590A}" src="https://github.com/user-attachments/assets/6516fa86-78ae-49ea-872d-71207c0b471b" />


Captura con nueva funcionalidad.
<img width="1145" height="416" alt="{F853316C-7D06-49D2-BE7D-B43645E470E0}" src="https://github.com/user-attachments/assets/3dd80476-8816-403c-b51f-b91141888cf9" />
