### PR TITLE
Feat/funcion creada para cambiar de titulo la pagina

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/icono-medicina-integral.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MI | </title>
+    <title>Vite + React</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/hooks/useCambiarTitulo.jsx
+++ b/src/hooks/useCambiarTitulo.jsx
@@ -1,0 +1,7 @@
+import { useEffect } from "react";
+
+export function useCambiarTitulo({title}){
+  useEffect(()=>{
+    document.title= `MI | ${title}`
+  },)
+}

--- a/src/pages/Dashboard/Dashboard.jsx
+++ b/src/pages/Dashboard/Dashboard.jsx
@@ -3,8 +3,11 @@ import { SubTitlePrincipal } from '../../components/SubTitlePrincipal/SubTitlePr
 import { SectionUno } from './Section-1/SectionUno'
 import { SectionDos } from './Section-2/SectionDos'
 import { SectionTres } from './Section-3/SectionTres'
-
+import { useCambiarTitulo } from '../../hooks/useCambiarTitulo'
 export function Dashboard(){
+  //Cambiar titulo de la pagina
+  useCambiarTitulo({title: 'Dashboard'})
+  //Retorno
   return(
     <>
       {/* Header de mi pantalla */}


### PR DESCRIPTION
<h2>Descripcion</h2>

<p>Se agregó una custom hook que permite cambiar el titulo en la pestaña del navegador.</p>

<h2>Uso:</h2>

- <h4> Importamos </h4>
     import { useCambiarTitulo } from '../../hooks/useCambiarTitulo'
- <h4> Usamos </h4>
     useCambiarTitulo({title: 'Dashboard'})

<h2>Vista</h2>

- <h4> Antes </h4>
![antes](https://github.com/user-attachments/assets/af593300-0673-4592-9137-aaf01d4ccf98)


- <h4> Despues </h4>
![despues](https://github.com/user-attachments/assets/ebae84be-0187-4169-a927-903915f562e1)

